### PR TITLE
Add AutoField test coverage for existing behaviours and document $ref handling

### DIFF
--- a/test/auto-field.spec.tsx
+++ b/test/auto-field.spec.tsx
@@ -1,0 +1,120 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AutoField } from "../src/components/autoform/auto-field";
+
+// The AutoField component contains a lot of conditional rendering paths based on
+// the JSON schema passed to it. These tests are intentionally focused on the
+// pieces of behaviour that are currently implemented so that future refactors
+// can lean on them for safety. Each test uses comments to describe the
+// expectations and the reasoning behind the chosen fixture data.
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AutoField", () => {
+  it("renders a fallback message when the provided schema is not an object", () => {
+    // The component guards against malformed schemas by checking the runtime
+    // shape. Passing a primitive should exercise that branch.
+    render(<AutoField jsonProperty={"not-a-schema" as any} />);
+
+    expect(
+      screen.getByText(/Invalid property schema: "not-a-schema"/i)
+    ).toBeInTheDocument();
+  });
+
+  it("uses the first entry from anyOf definitions", () => {
+    // anyOf currently renders the first schema option. We pass two options to
+    // make the intention explicit and assert that the first one is honoured.
+    render(
+      <AutoField
+        jsonProperty={{
+          anyOf: [
+            { type: "string" },
+            { type: "number" },
+          ],
+        } as any}
+      />
+    );
+
+    expect(screen.getByRole("textbox")).toHaveAttribute("type", "text");
+  });
+
+  it("renders specialised inputs for well-known string formats", () => {
+    // Email format maps to an <input type="email" />. Using a format the
+    // component already knows ensures we are asserting the present behaviour.
+    render(<AutoField jsonProperty={{ type: "string", format: "email" }} />);
+
+    expect(screen.getByRole("textbox")).toHaveAttribute("type", "email");
+  });
+
+  it("renders enum properties using a select dropdown", () => {
+    // Enumerations are rendered through the custom Select component. Because
+    // Radix Select portals its menu we assert against the trigger text which
+    // stays in the document.
+    render(
+      <AutoField
+        jsonProperty={{
+          type: "string",
+          enum: ["alpha", "beta"],
+        }}
+      />
+    );
+
+    expect(screen.getByText("Select value...")).toBeInTheDocument();
+  });
+
+  it("supports tuple-style arrays by delegating to the first item schema", () => {
+    // The implementation selects the first schema entry when an array of items
+    // (tuple) is provided. Using a boolean schema lets us assert against the
+    // checkbox input being rendered.
+    render(
+      <AutoField
+        jsonProperty={{
+          type: "array",
+          items: [{ type: "boolean" }],
+        }}
+      />
+    );
+
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+  });
+
+  it("renders nested object properties as a list", () => {
+    // Objects with explicit properties should be rendered as a nested list with
+    // headings. We check for the heading text to confirm the structure.
+    render(
+      <AutoField
+        jsonProperty={{
+          type: "object",
+          properties: {
+            title: { type: "string" },
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText(/title/i)).toBeInTheDocument();
+  });
+
+  it("renders key/value inputs when additionalProperties is allowed", () => {
+    // The additionalProperties branch renders a generic key/value pair when
+    // explicit properties are absent. We assert that the key input honours the
+    // pattern attribute when provided.
+    render(
+      <AutoField
+        jsonProperty={{
+          type: "object",
+          additionalProperties: { type: "string" },
+          propertyNames: { pattern: "^[a-z]+$" },
+        }}
+      />
+    );
+
+    expect(screen.getByPlaceholderText("key")).toHaveAttribute(
+      "pattern",
+      "^[a-z]+$"
+    );
+  });
+});

--- a/test/auto-form.spec.tsx
+++ b/test/auto-form.spec.tsx
@@ -1,0 +1,59 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, it } from "vitest";
+
+import { AutoForm } from "../src/components/autoform/auto-form";
+
+// replaceRefs is currently invoked as part of rendering AutoForm. These tests
+// focus on documenting how $ref entries are handled so future schema changes
+// keep the same behaviour unless intentionally updated.
+afterEach(() => {
+  cleanup();
+});
+
+describe("AutoForm $ref handling", () => {
+  it("replaces known refs using the corresponding $defs entry", () => {
+    // When the schema contains a $ref pointing to an entry under $defs the
+    // implementation swaps the reference for the full schema before passing it
+    // to AutoField. Using an email schema ensures we can assert against the
+    // specialised input that AutoField renders for string/email pairs.
+    render(
+      <AutoForm
+        schema={{
+          type: "object",
+          $defs: {
+            Email: { type: "string", format: "email" },
+          },
+          properties: {
+            contact: { $ref: "#/$defs/Email" },
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByRole("textbox")).toHaveAttribute("type", "email");
+  });
+
+  it("falls back to AutoField's error branch when the ref cannot be resolved", () => {
+    // If a property references an unknown definition the original value is
+    // preserved which means AutoField receives an object without a type field.
+    // AutoField currently renders a helpful message in that scenario; this test
+    // protects that behaviour.
+    render(
+      <AutoForm
+        schema={{
+          type: "object",
+          properties: {
+            missing: { $ref: "#/$defs/Nope" },
+          },
+        }}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        'No type found: {"$ref":"#/$defs/Nope"}'
+      )
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest suite covering AutoField rendering branches for primitives, enums, arrays, objects, and additionalProperties
- document the intent of each test with inline comments so future changes understand the expectations
- cover AutoForm's $ref replacement flow so the resolution and fallback paths stay documented

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d5c427d71083238c416b12878e3d2b