### PR TITLE
Add tests for HookAutoForm behaviours

### DIFF
--- a/src/components/autoform/example.tsx
+++ b/src/components/autoform/example.tsx
@@ -1,13 +1,21 @@
 import { asJsonSchema } from "../../../test/kitchen-sink-schema";
 import { AutoForm } from "./auto-form";
+import { HookAutoForm } from "./hook-auto-form";
+import type { JsonSchema } from "./types";
 
 export const Example = () => {
-  const input = asJsonSchema;
+  const input = asJsonSchema as JsonSchema;
 
   return (
-    <div className="space-y-4">
-      {/* @ts-ignore */}
-      <AutoForm schema={input} />
+    <div className="grid gap-10 md:grid-cols-2">
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">AutoForm</h2>
+        <AutoForm schema={input} />
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">HookAutoForm (react-hook-form)</h2>
+        <HookAutoForm schema={input} />
+      </section>
     </div>
   );
 };

--- a/src/components/autoform/hook-auto-field.tsx
+++ b/src/components/autoform/hook-auto-field.tsx
@@ -1,0 +1,362 @@
+import { useEffect, useMemo } from "react";
+import {
+  Controller,
+  useFieldArray,
+  useFormContext,
+  type FieldValues,
+} from "react-hook-form";
+
+import { Button } from "../ui/button";
+import { Checkbox } from "../ui/checkbox";
+import { Input } from "../ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+import type { JsonProperty } from "./types";
+import type { _JSONSchema } from "node_modules/zod/v4/core/json-schema.d.cts";
+
+const resolveSchema = (
+  schema: JsonProperty | _JSONSchema,
+): JsonProperty | _JSONSchema => {
+  if (
+    typeof schema === "object" &&
+    schema !== null &&
+    "anyOf" in schema &&
+    Array.isArray(schema.anyOf) &&
+    schema.anyOf.length > 0
+  ) {
+    return schema.anyOf[0];
+  }
+
+  return schema;
+};
+
+const getDefaultValueForSchema = (
+  schema: JsonProperty | _JSONSchema,
+): unknown => {
+  if (typeof schema !== "object" || schema === null) {
+    return null;
+  }
+
+  if (
+    "default" in schema &&
+    (schema as { default?: unknown }).default !== undefined
+  ) {
+    return (schema as { default?: unknown }).default;
+  }
+
+  if ("type" in schema && typeof schema.type === "string") {
+    switch (schema.type) {
+      case "string":
+        return "";
+      case "number":
+      case "integer":
+        return null;
+      case "boolean":
+        return false;
+      case "array":
+        return [];
+      case "object":
+        return {};
+      case "null":
+        return null;
+      default:
+        return null;
+    }
+  }
+
+  return null;
+};
+
+const HookArrayField = ({
+  name,
+  itemSchema,
+}: {
+  name: string;
+  itemSchema: JsonProperty | _JSONSchema;
+}) => {
+  const resolvedItemSchema = useMemo(
+    () => resolveSchema(itemSchema),
+    [itemSchema],
+  );
+
+  const { control, getValues, setValue } = useFormContext<FieldValues>();
+
+  useEffect(() => {
+    const currentValue = getValues(name);
+    if (typeof currentValue === "undefined") {
+      setValue(name, []);
+    }
+  }, [getValues, name, setValue]);
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name,
+  });
+
+  return (
+    <div className="space-y-3">
+      <ul className="space-y-3">
+        {fields.map((field, index) => (
+          <li key={field.id} className="flex items-start gap-3">
+            <div className="flex-1 space-y-2">
+              <HookAutoField
+                name={`${name}.${index}`}
+                jsonProperty={resolvedItemSchema}
+              />
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => remove(index)}
+            >
+              Remove
+            </Button>
+          </li>
+        ))}
+      </ul>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => append(getDefaultValueForSchema(resolvedItemSchema))}
+      >
+        Add item
+      </Button>
+    </div>
+  );
+};
+
+export const HookAutoField = ({
+  name,
+  jsonProperty,
+  required,
+}: {
+  name: string;
+  jsonProperty: JsonProperty | _JSONSchema;
+  required?: boolean;
+}) => {
+  const schema = resolveSchema(jsonProperty);
+  const { control, register } = useFormContext<FieldValues>();
+
+  if (typeof schema !== "object" || schema === null) {
+    return <span>Invalid property schema: {JSON.stringify(schema)}</span>;
+  }
+
+  if (!("type" in schema)) {
+    return <span>No type found: {JSON.stringify(schema)}</span>;
+  }
+
+  if ("enum" in schema && Array.isArray(schema.enum) && schema.enum.length > 0) {
+    const options = schema.enum.map((option) => ({
+      key: String(option),
+      value: option,
+    }));
+
+    return (
+      <Controller
+        control={control}
+        name={name}
+        render={({ field }) => {
+          const selected = options.find((option) =>
+            Object.is(option.value, field.value),
+          );
+
+          return (
+            <Select
+              value={selected?.key ?? ""}
+              onValueChange={(value) => {
+                const match = options.find((option) => option.key === value);
+                field.onChange(match?.value ?? value);
+              }}
+            >
+              <SelectTrigger aria-required={required}>
+                <SelectValue placeholder="Select value..." />
+              </SelectTrigger>
+              <SelectContent>
+                {options.map((option) => (
+                  <SelectItem key={option.key} value={option.key}>
+                    {String(option.value)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          );
+        }}
+      />
+    );
+  }
+
+  const type = schema.type;
+
+  switch (type) {
+    case "array": {
+      const items = (schema as {
+        items?: JsonProperty | JsonProperty[] | true;
+      }).items;
+
+      if (!items) {
+        return <span className="text-muted-foreground">[]</span>;
+      }
+
+      if (Array.isArray(items)) {
+        return <HookArrayField name={name} itemSchema={items[0] ?? {}} />;
+      }
+
+      if (items === true) {
+        return <HookArrayField name={name} itemSchema={{ type: "string" }} />;
+      }
+
+      return <HookArrayField name={name} itemSchema={items} />;
+    }
+
+    case "object": {
+      const properties = (schema as {
+        properties?: Record<string, JsonProperty | _JSONSchema>;
+        required?: string[];
+        additionalProperties?: unknown;
+      }).properties;
+      const requiredKeys = new Set(
+        (schema as { required?: string[] }).required ?? [],
+      );
+
+      if (properties && Object.keys(properties).length > 0) {
+        return (
+          <ul className="space-y-3 rounded-md border p-4">
+            {Object.entries(properties).map(([key, value]) => (
+              <li key={key} className="space-y-2">
+                <label
+                  htmlFor={`${name}.${key}`}
+                  className="text-sm font-medium"
+                >
+                  {key}
+                  {requiredKeys.has(key) ? (
+                    <span className="text-destructive ml-1">*</span>
+                  ) : null}
+                </label>
+                <HookAutoField
+                  name={`${name}.${key}`}
+                  jsonProperty={value}
+                  required={requiredKeys.has(key)}
+                />
+              </li>
+            ))}
+          </ul>
+        );
+      }
+
+      if ("additionalProperties" in schema) {
+        return (
+          <span className="text-muted-foreground">
+            Record-style objects are not yet supported in HookAutoForm.
+          </span>
+        );
+      }
+
+      return <span className="text-muted-foreground">{`{ }`}</span>;
+    }
+
+    case "string": {
+      const format =
+        Object.prototype.hasOwnProperty.call(schema, "format")
+          ? (schema as { format?: string }).format
+          : undefined;
+
+      switch (format) {
+        case "email":
+          return (
+            <Input
+              id={name}
+              type="email"
+              aria-required={required}
+              {...register(name)}
+            />
+          );
+        case "uri":
+          return (
+            <Input
+              id={name}
+              type="url"
+              aria-required={required}
+              {...register(name)}
+            />
+          );
+        case "date-time":
+          return (
+            <Input
+              id={name}
+              type="datetime-local"
+              aria-required={required}
+              {...register(name)}
+            />
+          );
+        case "date":
+          return (
+            <Input
+              id={name}
+              type="date"
+              aria-required={required}
+              {...register(name)}
+            />
+          );
+        case "time":
+          return (
+            <Input
+              id={name}
+              type="time"
+              step={1}
+              aria-required={required}
+              {...register(name)}
+            />
+          );
+        default:
+          return (
+            <Input
+              id={name}
+              type="text"
+              aria-required={required}
+              {...register(name)}
+            />
+          );
+      }
+    }
+
+    case "number":
+    case "integer":
+      return (
+        <Input
+          id={name}
+          type="number"
+          aria-required={required}
+          {...register(name, { valueAsNumber: true })}
+        />
+      );
+
+    case "boolean":
+      return (
+        <Controller
+          control={control}
+          name={name}
+          render={({ field }) => (
+            <Checkbox
+              id={name}
+              checked={Boolean(field.value)}
+              aria-required={required}
+              onCheckedChange={(checked) => field.onChange(Boolean(checked))}
+            />
+          )}
+        />
+      );
+
+    case "null":
+      return <span className="font-mono">null</span>;
+
+    default:
+      return (
+        <span>Unsupported field type: {JSON.stringify(schema)}</span>
+      );
+  }
+};

--- a/src/components/autoform/hook-auto-form.tsx
+++ b/src/components/autoform/hook-auto-form.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { FormProvider, useForm, type FieldValues } from "react-hook-form";
+
+import { Button } from "../ui/button";
+import { HookAutoField } from "./hook-auto-field";
+import { replaceRefs } from "./auto-form";
+import type { JsonSchema } from "./types";
+
+export type HookAutoFormProps = {
+  schema: JsonSchema;
+  defaultValues?: FieldValues;
+  onSubmit?: (values: FieldValues) => void;
+};
+
+export const HookAutoForm = ({
+  schema,
+  defaultValues,
+  onSubmit,
+}: HookAutoFormProps) => {
+  const resolvedSchema = replaceRefs(schema);
+  const form = useForm<FieldValues>({
+    defaultValues,
+  });
+  const [lastSubmittedValues, setLastSubmittedValues] = useState<FieldValues | null>(
+    null,
+  );
+
+  const handleSubmit = form.handleSubmit((values) => {
+    setLastSubmittedValues(values);
+    onSubmit?.(values);
+  });
+
+  const currentValues = form.watch();
+  const requiredFields = new Set(resolvedSchema.required ?? []);
+
+  return (
+    <FormProvider {...form}>
+      <form className="space-y-6" onSubmit={handleSubmit}>
+        <ul className="space-y-4">
+          {Object.entries(resolvedSchema.properties ?? {}).map(
+            ([key, value]) => (
+              <li key={key} className="space-y-2">
+                <label className="text-sm font-medium" htmlFor={key}>
+                  {key}
+                  {requiredFields.has(key) ? (
+                    <span className="text-destructive ml-1">*</span>
+                  ) : null}
+                </label>
+                <HookAutoField
+                  name={key}
+                  jsonProperty={value}
+                  required={requiredFields.has(key)}
+                />
+              </li>
+            ),
+          )}
+        </ul>
+
+        <div className="flex items-center gap-3">
+          <Button type="submit">Submit</Button>
+          <Button type="button" variant="outline" onClick={() => form.reset()}>
+            Reset
+          </Button>
+        </div>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <h3 className="text-sm font-semibold">Live values</h3>
+            <pre className="max-h-64 overflow-auto rounded-md bg-muted p-4 text-xs">
+              {JSON.stringify(currentValues, null, 2)}
+            </pre>
+          </div>
+          {lastSubmittedValues ? (
+            <div className="space-y-2">
+              <h3 className="text-sm font-semibold">Last submitted values</h3>
+              <pre className="max-h-64 overflow-auto rounded-md bg-muted p-4 text-xs">
+                {JSON.stringify(lastSubmittedValues, null, 2)}
+              </pre>
+            </div>
+          ) : null}
+        </div>
+      </form>
+    </FormProvider>
+  );
+};

--- a/test/hook-auto-form.spec.tsx
+++ b/test/hook-auto-form.spec.tsx
@@ -1,0 +1,154 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { HookAutoForm } from "../src/components/autoform/hook-auto-form";
+
+beforeAll(() => {
+  class MockResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    // @ts-expect-error - jsdom does not provide ResizeObserver in the test environment
+    globalThis.ResizeObserver = MockResizeObserver;
+  }
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("HookAutoForm", () => {
+  it("resolves $ref entries before rendering inputs", () => {
+    render(
+      <HookAutoForm
+        schema={{
+          type: "object",
+          $defs: {
+            Email: { type: "string", format: "email" },
+          },
+          properties: {
+            contact: { $ref: "#/$defs/Email" },
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByRole("textbox")).toHaveAttribute("type", "email");
+  });
+
+  it("submits collected values via react-hook-form", async () => {
+    const user = userEvent.setup();
+    const handleSubmit = vi.fn();
+
+    render(
+      <HookAutoForm
+        onSubmit={handleSubmit}
+        schema={{
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            optIn: { type: "boolean" },
+          },
+          required: ["name", "optIn"],
+        }}
+      />
+    );
+
+    await user.type(screen.getByLabelText(/name/i), "Alice");
+    await user.click(screen.getByLabelText(/optIn/i));
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+    expect(handleSubmit).toHaveBeenCalledWith({ name: "Alice", optIn: true });
+  });
+
+  it("allows adding and removing array items", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <HookAutoForm
+        schema={{
+          type: "object",
+          properties: {
+            tags: {
+              type: "array",
+              items: { type: "string" },
+            },
+          },
+        }}
+      />
+    );
+
+    const addButton = screen.getByRole("button", { name: /add item/i });
+
+    await user.click(addButton);
+    let textboxes = screen.getAllByRole("textbox");
+    expect(textboxes).toHaveLength(1);
+
+    await user.type(textboxes[0], "first");
+
+    await user.click(addButton);
+    textboxes = screen.getAllByRole("textbox");
+    expect(textboxes).toHaveLength(2);
+
+    await user.type(textboxes[1], "second");
+
+    const removeButtons = screen.getAllByRole("button", { name: "Remove" });
+    await user.click(removeButtons[0]);
+
+    const remaining = screen.getAllByRole("textbox");
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]).toHaveValue("second");
+  });
+
+  it("resets the form back to provided default values", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <HookAutoForm
+        schema={{
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            tags: {
+              type: "array",
+              items: { type: "string" },
+            },
+          },
+        }}
+        defaultValues={{
+          name: "Initial",
+          tags: ["existing"],
+        }}
+      />
+    );
+
+    const nameInput = screen.getByLabelText(/name/i);
+    expect(nameInput).toHaveValue("Initial");
+
+    const existingTagInput = screen.getByDisplayValue("existing");
+
+    await user.clear(nameInput);
+    await user.type(nameInput, "Changed");
+
+    await user.clear(existingTagInput);
+    await user.type(existingTagInput, "override");
+
+    await user.click(screen.getByRole("button", { name: /add item/i }));
+    const newTagInput = screen.getAllByRole("textbox").at(-1);
+    expect(newTagInput).not.toBe(existingTagInput);
+    await user.type(newTagInput!, "another");
+
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+
+    expect(screen.getByLabelText(/name/i)).toHaveValue("Initial");
+    expect(screen.getByDisplayValue("existing")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("override")).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue("another")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- cover HookAutoForm with tests for $ref resolution, submission, array helpers, and reset behaviour
- polyfill ResizeObserver in the test environment to support Radix primitives

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d5c8780bec83239b4db4885d1b9fd2