### PR TITLE
Add ZodAutoForm wrapper with native Date support

### DIFF
--- a/src/components/autoform/auto-form.tsx
+++ b/src/components/autoform/auto-form.tsx
@@ -93,6 +93,7 @@ export const AutoForm = ({
 
 function normalizeAnyOfValues(values: unknown): unknown {
   if (values == null || typeof values !== "object") return values;
+  if (values instanceof Date) return values;
 
   if (Array.isArray(values)) {
     return values.map((v) => normalizeAnyOfValues(v));

--- a/src/components/autoform/example.tsx
+++ b/src/components/autoform/example.tsx
@@ -1,13 +1,32 @@
 import { asJsonSchema } from "../../../test/kitchen-sink-schema";
 import { AutoForm } from "./auto-form";
+import { ZodAutoForm } from "./zod-auto-form";
+import { z } from "zod";
+
+const MeetingSchema = z.object({
+  topic: z.string().min(1),
+  startsAt: z.date(),
+  followUpOn: z.date().optional(),
+});
 
 export const Example = () => {
   const input = asJsonSchema;
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-8">
       <h2 className="text-lg font-semibold">AutoForm</h2>
       <AutoForm schema={input} />
+
+      <div className="space-y-4">
+        <h2 className="text-lg font-semibold">ZodAutoForm</h2>
+        <ZodAutoForm
+          schema={MeetingSchema}
+          defaultValues={{
+            topic: "Quarterly sync",
+            startsAt: new Date(),
+          }}
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/autoform/zod-auto-form.tsx
+++ b/src/components/autoform/zod-auto-form.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from "react";
+import { z } from "zod";
+
+import { AutoForm, type AutoFormProps } from "./auto-form";
+import type { JsonSchema } from "./types";
+
+type ToJSONSchemaParams = Parameters<typeof z.toJSONSchema>[1];
+
+type ZodAutoFormProps<TSchema extends z.ZodTypeAny> = Omit<
+  AutoFormProps,
+  "schema"
+> & {
+  schema: TSchema;
+  toJSONSchemaOptions?: ToJSONSchemaParams;
+};
+
+const AUTOFORM_NATIVE_TYPE_KEY = "x-autoform-nativeType" as const;
+
+export const ZodAutoForm = <TSchema extends z.ZodTypeAny>({
+  schema,
+  toJSONSchemaOptions,
+  ...rest
+}: ZodAutoFormProps<TSchema>) => {
+  const jsonSchema = useMemo(() => {
+    const userOptions = toJSONSchemaOptions ?? {};
+    const userOverride = userOptions.override;
+
+    const mergedOptions: ToJSONSchemaParams = {
+      ...userOptions,
+      reused: userOptions.reused ?? "ref",
+      override: (ctx) => {
+        applyNativeDateOverride(ctx);
+        userOverride?.(ctx);
+      },
+    };
+
+    try {
+      return z.toJSONSchema(schema, mergedOptions) as JsonSchema;
+    } catch (error) {
+      if (isDateUnrepresentableError(error)) {
+        return z.toJSONSchema(schema, {
+          ...mergedOptions,
+          unrepresentable: "any",
+        }) as JsonSchema;
+      }
+      throw error;
+    }
+  }, [schema, toJSONSchemaOptions]);
+
+  return <AutoForm {...rest} schema={jsonSchema} />;
+};
+
+type OverrideContext = NonNullable<ToJSONSchemaParams>["override"] extends (
+  ctx: infer C
+) => void
+  ? C
+  : never;
+
+const isDateUnrepresentableError = (error: unknown): boolean =>
+  error instanceof Error &&
+  error.message.includes("Date cannot be represented in JSON Schema");
+
+const applyNativeDateOverride = (ctx: OverrideContext) => {
+  const { zodSchema, jsonSchema } = ctx;
+  if (!zodSchema || typeof zodSchema !== "object") return;
+
+  const internals = (zodSchema as { _zod?: { def?: { type?: string }; bag?: unknown } })
+    ._zod;
+  if (!internals) return;
+
+  if (internals.def?.type !== "date") return;
+
+  const target = jsonSchema as Record<string, unknown>;
+  target.type = "string";
+  target.format = "date-time";
+  target[AUTOFORM_NATIVE_TYPE_KEY] = "date";
+
+  const bag = internals.bag as
+    | {
+        minimum?: Date;
+        maximum?: Date;
+      }
+    | undefined;
+
+  if (bag?.minimum instanceof Date) {
+    target.formatMinimum = bag.minimum.toISOString();
+  }
+
+  if (bag?.maximum instanceof Date) {
+    target.formatMaximum = bag.maximum.toISOString();
+  }
+};
+
+export type { ZodAutoFormProps };


### PR DESCRIPTION
## Summary
- add a `ZodAutoForm` component that converts Zod schemas to JSON Schema (defaulting to `{ reused: "ref" }`)
- teach the renderer to recognise native Date metadata and keep values as `Date` instances
- expand the example and README to highlight the new wrapper and date handling

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Vite cannot resolve `@radix-ui/react-tabs` while running Vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fecc52e483239cb0d1f3bbed95b1