### PR TITLE
Add validation pipeline and enforce required collections

### DIFF
--- a/docs/form-normalization-plan.md
+++ b/docs/form-normalization-plan.md
@@ -1,0 +1,63 @@
+# Form Normalization & Validation Simplification Plan
+
+## Background
+- The current `normalizeFieldValue` implementation mirrors `buildDefaultValue`, resulting in an intertwined flow that is difficult to follow.
+- Validation rules are scattered between schema definitions and ad-hoc checks inside normalization, which blurs responsibilities.
+- Complex field types (records, unions, nested objects) use nested reducers and type coercions that obscure intent, making maintenance risky.
+- There are **no live customers** depending on existing quirks, so we can prioritize clarity over backward compatibility in the refactor.
+
+## Goals
+1. **Clarify responsibilities** between normalization (shaping user input) and validation (ensuring correctness).
+2. **Prefer readability over cleverness**: choose straightforward control flow and explicit helper functions.
+3. **Improve developer guidance** with in-line documentation and consistent naming.
+4. **Support incremental adoption** so that the refactor can land in stages without breaking consumers.
+
+## Proposed Architecture
+1. **Introduce dedicated normalizer modules**
+   - Create `src/lib/auto-form/normalizers/` with one file per field family (`object.ts`, `array.ts`, `record.ts`, `union.ts`, `primitive.ts`).
+   - Each module exports a `normalize` function with a shared signature: `(field, value, context) => NormalizedValue`.
+   - Provide a top-level `normalizeValue` orchestrator that delegates based on `field.type`.
+   - Motivation: smaller files, cohesive logic, easier to test in isolation.
+
+2. **Separate validation concerns**
+   - Implement a lightweight validation pipeline in `src/lib/auto-form/validation/`.
+   - Validation functions should **only** report issues (e.g., `ValidationIssue[]`) without mutating values.
+   - Normalize first, then run validation on the normalized payload before submission.
+   - Existing Zod schemas can still power type-level guarantees; runtime validation will focus on business rules (required keys, min/max, etc.).
+
+3. **Shared context object**
+   - Define a `NormalizationContext` that carries utilities required by both normalization and validation (e.g., date formatters, locale-specific helpers).
+   - Document the contract in a dedicated `context.ts` file to prevent "mystery dependencies" creeping into helpers.
+
+4. **Comment-driven guidance**
+   - Prepend each normalizer with a `// WHY:` block summarizing the intent and edge cases it handles.
+   - Document the public surface (function signatures, expected inputs/outputs) using TSDoc-style comments.
+   - Add a README in the new `normalizers/` folder describing data flow at a high level.
+
+5. **Reduce implicit coercions and default values**
+   - Replace reducers with explicit loops for clarity, especially when building objects from records.
+   - Extract helper functions such as `safeNumberKey` and `ensureArray` with descriptive names.
+   - Emit `undefined` for empty field values (rather than empty strings or other sentinels) so downstream validation sees an explicit "unset" state.
+   - During validation, flag coercion failures instead of silently dropping data (e.g., invalid number keys).
+
+## Migration Strategy
+1. **Phase 1: Extract normalizer orchestrator**
+   - Move existing logic into new modules without changing external APIs.
+   - Add unit tests per module to codify current behavior.
+
+2. **Phase 2: Introduce validation pipeline**
+   - Implement validation modules mirroring the normalization structure.
+   - Update form submission flow to run `validate(normalizedValues)` and surface user-friendly errors.
+   - If validation returns issues, block submission until the user resolves them.
+
+3. **Phase 3: Clean up & document**
+   - Remove legacy helper functions (`normalizeFieldValue`, record reducers, etc.).
+   - Expand documentation and comments, ensuring developers can trace data flow from schema ➜ normalization ➜ validation.
+
+## Open Questions
+- None. With no external consumers, we can freely re-shape normalization defaults and validation semantics to favor clarity.
+
+## Next Steps
+- Align with stakeholders on the phased approach and confirm testing expectations.
+- Schedule implementation tasks per phase, ensuring CI coverage for new helpers.
+- Begin with Phase 1 extraction, emphasizing readable, well-commented code.

--- a/src/lib/auto-form/date-helpers.ts
+++ b/src/lib/auto-form/date-helpers.ts
@@ -1,0 +1,73 @@
+/**
+ * Attempts to coerce an arbitrary value into a valid {@link Date} instance.
+ *
+ * @param value - Raw value coming from default values, form state, or schema.
+ * @returns A {@link Date} when the value can be interpreted as one, otherwise `undefined`.
+ */
+export const parseDateValue = (value: unknown): Date | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? undefined : value;
+  }
+
+  if (typeof value === "string") {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? undefined : date;
+  }
+
+  return undefined;
+};
+
+/**
+ * Normalizes a date-like value into the `YYYY-MM-DD` string used by native date inputs.
+ *
+ * @param value - Any value that might represent a date (string, Date, etc.).
+ * @returns A formatted date string or an empty string when the value is not a valid date.
+ */
+export const formatDateForInput = (value: unknown): string => {
+  const date = parseDateValue(value);
+
+  if (!date) {
+    return "";
+  }
+
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+};
+
+/**
+ * Extracts the `HH:MM` portion from time-like values so they can be consumed by time inputs.
+ *
+ * @param value - A string or {@link Date} potentially containing a time component.
+ * @returns The first five characters of the time component or `undefined` if unavailable.
+ */
+export const extractTimeValue = (value: unknown): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  if (value instanceof Date) {
+    return value.toTimeString().slice(0, 5);
+  }
+
+  if (typeof value === "string") {
+    if (value.includes("T")) {
+      const [, timePart] = value.split("T");
+      if (timePart) {
+        return timePart.slice(0, 5);
+      }
+    }
+
+    if (/^\d{2}:\d{2}/.test(value)) {
+      return value.slice(0, 5);
+    }
+  }
+
+  return undefined;
+};

--- a/src/lib/auto-form/normalizers/README.md
+++ b/src/lib/auto-form/normalizers/README.md
@@ -1,0 +1,22 @@
+# Auto Form Normalizers
+
+Documenting the normalization flow prevents future refactors from re-introducing
+hidden coupling between form state and validation.
+
+The helpers in this folder mirror the Auto Form schema and produce the payload
+shape consumed by submission handlers. Each file focuses on a single field
+family so new contributors can zero in on the logic they need without paging
+through unrelated branches.
+
+- `object.ts`, `array.ts`, `record.ts`, and `union.ts` delegate to one another to
+  recursively normalize complex structures.
+- `primitive.ts` guards primitive values against loosely typed inputs such as
+  `Date` instances.
+- `index.ts` exposes `normalizeValue`, the orchestrator used by higher level form
+  helpers.
+- `types.ts` centralizes shared types, giving later phases a stable location to
+  grow the normalization context and union option helpers.
+
+Future phases will layer validation on top of this normalization pass. Keeping
+this folder cohesive reduces the surface area that follow-up work needs to
+understand.

--- a/src/lib/auto-form/normalizers/array.ts
+++ b/src/lib/auto-form/normalizers/array.ts
@@ -1,0 +1,17 @@
+import type { AnyField, NormalizationContext, NormalizerFn } from "./types";
+
+// WHY: Arrays in the UI often contain transient placeholders. Filtering with a
+// single `Array.isArray` check ensures we only normalize real items and reuse
+// the shared logic for each element type.
+export const normalizeArrayField = (
+  field: Extract<AnyField, { type: "array" }>,
+  value: unknown,
+  context: NormalizationContext,
+  normalize: NormalizerFn
+): unknown[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.map((item) => normalize(field.itemType as AnyField, item, context));
+};

--- a/src/lib/auto-form/normalizers/index.ts
+++ b/src/lib/auto-form/normalizers/index.ts
@@ -1,0 +1,32 @@
+import { normalizeArrayField } from "./array";
+import { normalizeObjectField } from "./object";
+import { normalizePrimitiveField } from "./primitive";
+import { normalizeRecordField } from "./record";
+import { normalizeUnionField } from "./union";
+import type { AnyField, NormalizationContext } from "./types";
+
+const DEFAULT_CONTEXT: NormalizationContext = {};
+
+/**
+ * Delegates normalization to field-family specific helpers.
+ */
+export const normalizeValue = (
+  field: AnyField,
+  value: unknown,
+  context: NormalizationContext = DEFAULT_CONTEXT
+): unknown => {
+  switch (field.type) {
+    case "object":
+      return normalizeObjectField(field, value, context, normalizeValue);
+    case "array":
+      return normalizeArrayField(field, value, context, normalizeValue);
+    case "record":
+      return normalizeRecordField(field, value, context, normalizeValue);
+    case "union":
+      return normalizeUnionField(field, value, context, normalizeValue);
+    default:
+      return normalizePrimitiveField(field, value, context);
+  }
+};
+
+export type { NormalizationContext } from "./types";

--- a/src/lib/auto-form/normalizers/object.ts
+++ b/src/lib/auto-form/normalizers/object.ts
@@ -1,0 +1,23 @@
+import type { AnyField, NormalizationContext, NormalizerFn } from "./types";
+
+// WHY: Object fields own a nested schema tree. Recursively normalizing each
+// property keeps deeply nested forms predictable, even when users omit values.
+export const normalizeObjectField = (
+  field: Extract<AnyField, { type: "object" }>,
+  value: unknown,
+  context: NormalizationContext,
+  normalize: NormalizerFn
+): Record<string, unknown> => {
+  const source =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+
+  return Object.entries(field.properties).reduce<Record<string, unknown>>(
+    (acc, [key, subField]) => {
+      acc[key] = normalize(subField as AnyField, source[key], context);
+      return acc;
+    },
+    {}
+  );
+};

--- a/src/lib/auto-form/normalizers/primitive.ts
+++ b/src/lib/auto-form/normalizers/primitive.ts
@@ -1,0 +1,71 @@
+import { extractTimeValue, formatDateForInput } from "../date-helpers";
+import type { AnyField, NormalizationContext } from "./types";
+
+// WHY: Primitive fields already align with form inputs. The normalizer simply
+// defends against `Date` instances or loosely typed values sneaking through so
+// downstream consumers see consistent strings or booleans.
+export const normalizePrimitiveField = (
+  field: AnyField,
+  value: unknown,
+  _context: NormalizationContext
+): unknown => {
+  switch (field.type) {
+    case "string":
+    case "email":
+    case "password":
+    case "url": {
+      if (typeof value !== "string" || value === "") {
+        return undefined;
+      }
+
+      return value;
+    }
+    case "date": {
+      if (typeof value === "string") {
+        return value === "" ? undefined : value;
+      }
+
+      const formatted = formatDateForInput(value);
+      return formatted === "" ? undefined : formatted;
+    }
+    case "time": {
+      if (typeof value === "string") {
+        return value === "" ? undefined : value;
+      }
+
+      return extractTimeValue(value);
+    }
+    case "datetime": {
+      if (!value || typeof value !== "object") {
+        return undefined;
+      }
+
+      const rawDate = (value as { date?: unknown }).date;
+      const rawTime = (value as { time?: unknown }).time;
+
+      const datePart =
+        typeof rawDate === "string" ? rawDate : formatDateForInput(rawDate);
+      const timePart =
+        typeof rawTime === "string"
+          ? rawTime
+          : extractTimeValue(rawTime) ?? undefined;
+
+      if (!datePart && !timePart) {
+        return undefined;
+      }
+
+      const formattedDate =
+        typeof datePart === "string" && datePart !== ""
+          ? datePart
+          : undefined;
+
+      if (!formattedDate) {
+        return timePart;
+      }
+
+      return timePart ? `${formattedDate}T${timePart}` : formattedDate;
+    }
+    default:
+      return value;
+  }
+};

--- a/src/lib/auto-form/normalizers/record.ts
+++ b/src/lib/auto-form/normalizers/record.ts
@@ -1,0 +1,40 @@
+import type { AnyField, NormalizationContext, NormalizerFn } from "./types";
+
+// WHY: Records are modeled as arrays of `{ key, value }` entries in the form UI.
+// Rebuilding a plain object keeps the submit payload ergonomic while silently
+// dropping malformed keys to match the legacy behavior.
+export const normalizeRecordField = (
+  field: Extract<AnyField, { type: "record" }>,
+  value: unknown,
+  context: NormalizationContext,
+  normalize: NormalizerFn
+): Record<string, unknown> => {
+  if (!Array.isArray(value)) {
+    return {};
+  }
+
+  return value.reduce<Record<string, unknown>>((acc, entry) => {
+    if (!entry || typeof entry !== "object") {
+      return acc;
+    }
+
+    const rawKey = (entry as { key?: unknown }).key;
+    if (rawKey === undefined || rawKey === null || rawKey === "") {
+      return acc;
+    }
+
+    const normalizedKey =
+      field.keyType === "number" ? Number(rawKey) : String(rawKey);
+
+    if (field.keyType === "number" && Number.isNaN(normalizedKey)) {
+      return acc;
+    }
+
+    acc[String(normalizedKey)] = normalize(
+      field.valueType,
+      (entry as { value?: unknown }).value,
+      context
+    );
+    return acc;
+  }, {});
+};

--- a/src/lib/auto-form/normalizers/types.ts
+++ b/src/lib/auto-form/normalizers/types.ts
@@ -1,0 +1,26 @@
+import type { FieldSchema } from "../schemas";
+import type z from "zod";
+
+/**
+ * Shared field type used by all normalizers.
+ */
+export type AnyField = z.infer<typeof FieldSchema>;
+
+/**
+ * Placeholder for future shared utilities needed during normalization.
+ *
+ * Phase 1 keeps this context intentionally minimal so later phases can grow
+ * it without rewriting each normalizer signature.
+ */
+export interface NormalizationContext {}
+
+export interface UnionOptionsValue {
+  selected: number;
+  options: unknown[];
+}
+
+export type NormalizerFn = (
+  field: AnyField,
+  value: unknown,
+  context: NormalizationContext
+) => unknown;

--- a/src/lib/auto-form/normalizers/union.ts
+++ b/src/lib/auto-form/normalizers/union.ts
@@ -1,0 +1,33 @@
+import type {
+  AnyField,
+  NormalizationContext,
+  NormalizerFn,
+  UnionOptionsValue,
+} from "./types";
+
+// WHY: Union fields capture both the selected option and the per-option payloads
+// so the UI can seamlessly switch between choices. Normalizing ensures every
+// option slot is hydrated, even when the user never touched it.
+export const normalizeUnionField = (
+  field: Extract<AnyField, { type: "union" }>,
+  value: unknown,
+  context: NormalizationContext,
+  normalize: NormalizerFn
+): UnionOptionsValue => {
+  if (!value || typeof value !== "object") {
+    return {
+      selected: 0,
+      options: field.anyOf.map((option) => normalize(option, undefined, context)),
+    } satisfies UnionOptionsValue;
+  }
+
+  const unionValue = value as UnionOptionsValue;
+  const selectedIndex = Number((unionValue as { selected?: unknown }).selected ?? 0);
+
+  return {
+    selected: Number.isNaN(selectedIndex) ? 0 : selectedIndex,
+    options: field.anyOf.map((option, index) =>
+      normalize(option, unionValue.options?.[index], context)
+    ),
+  } satisfies UnionOptionsValue;
+};

--- a/src/lib/auto-form/validation/array.ts
+++ b/src/lib/auto-form/validation/array.ts
@@ -1,0 +1,34 @@
+import type { AnyField } from "../normalizers/types";
+import { ensureRequired } from "./helpers";
+import type { ValidationContext, ValidationIssue, ValidatorFn } from "./types";
+
+// WHY: Arrays combine a required check with per-item validation so collections
+// surface both structural and item-level issues.
+export const validateArrayField = (
+  field: Extract<AnyField, { type: "array" }>,
+  value: unknown,
+  context: ValidationContext,
+  path: string[],
+  validate: ValidatorFn
+): ValidationIssue[] => {
+  const items = Array.isArray(value) ? value : [];
+  const issues: ValidationIssue[] = [];
+
+  const requiredIssues = ensureRequired(field, items, path);
+  if (requiredIssues.length > 0) {
+    return requiredIssues;
+  }
+
+  items.forEach((item, index) => {
+    issues.push(
+      ...validate(
+        field.itemType as AnyField,
+        item,
+        context,
+        [...path, index.toString()]
+      )
+    );
+  });
+
+  return issues;
+};

--- a/src/lib/auto-form/validation/helpers.ts
+++ b/src/lib/auto-form/validation/helpers.ts
@@ -1,0 +1,83 @@
+import type { AnyField } from "../normalizers/types";
+import type { ValidationIssue } from "./types";
+
+/**
+ * Produces a uniform validation issue payload for downstream consumers.
+ */
+export const createIssue = (path: string[], message: string): ValidationIssue => ({
+  path,
+  message,
+});
+
+/**
+ * Determines whether a value should be treated as "empty" for validation
+ * purposes. This mirrors how normalization collapses empty inputs into
+ * `undefined` so validation can consistently reason about missing data.
+ */
+export const isValueEmpty = (value: unknown): boolean => {
+  if (value === undefined) {
+    return true;
+  }
+
+  if (value === null) {
+    return true;
+  }
+
+  if (typeof value === "string") {
+    return value.trim() === "";
+  }
+
+  if (typeof value === "number") {
+    return Number.isNaN(value);
+  }
+
+  if (typeof value === "boolean") {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0 || value.every(isValueEmpty);
+  }
+
+  if (value && typeof value === "object") {
+    const entries = Object.values(value as Record<string, unknown>);
+
+    if (entries.length === 0) {
+      return true;
+    }
+
+    return entries.every(isValueEmpty);
+  }
+
+  return false;
+};
+
+/**
+ * Generates a default message for required-field violations while honoring any
+ * schema-provided override.
+ */
+const requiredMessageFor = (field: AnyField): string =>
+  field.errorMessage ?? `${field.title} is required`;
+
+/**
+ * Validates required-flag semantics for a single field.
+ */
+export const ensureRequired = (
+  field: AnyField,
+  value: unknown,
+  path: string[]
+): ValidationIssue[] => {
+  if (!field.required) {
+    return [];
+  }
+
+  if (value === null && field.nullable) {
+    return [];
+  }
+
+  if (isValueEmpty(value)) {
+    return [createIssue(path, requiredMessageFor(field))];
+  }
+
+  return [];
+};

--- a/src/lib/auto-form/validation/index.ts
+++ b/src/lib/auto-form/validation/index.ts
@@ -1,0 +1,50 @@
+import { validateArrayField } from "./array";
+import { validateObjectField } from "./object";
+import { validatePrimitiveField } from "./primitive";
+import { validateRecordField } from "./record";
+import { validateUnionField } from "./union";
+import type { ValidationContext, ValidationIssue, ValidatorFn } from "./types";
+import type { AnyField } from "../normalizers/types";
+import type { FieldSchema } from "../schemas";
+import type z from "zod";
+
+const DEFAULT_CONTEXT: ValidationContext = {};
+
+/**
+ * Delegates validation to field-family specific helpers.
+ */
+export const validateValue: ValidatorFn = (
+  field,
+  value,
+  context = DEFAULT_CONTEXT,
+  path
+) => {
+  const typedField = field as AnyField;
+
+  switch (typedField.type) {
+    case "object":
+      return validateObjectField(typedField, value, context, path, validateValue);
+    case "array":
+      return validateArrayField(typedField, value, context, path, validateValue);
+    case "record":
+      return validateRecordField(typedField, value, context, path);
+    case "union":
+      return validateUnionField(typedField, value, context, path, validateValue);
+    default:
+      return validatePrimitiveField(typedField, value, context, path);
+  }
+};
+
+/**
+ * Validates an entire form payload using the provided schema definition.
+ */
+export const validateFormValues = (
+  values: Record<string, unknown>,
+  fields: Record<string, z.infer<typeof FieldSchema>>,
+  context: ValidationContext = DEFAULT_CONTEXT
+): ValidationIssue[] =>
+  Object.entries(fields).flatMap(([key, field]) =>
+    validateValue(field, values[key], context, [key])
+  );
+
+export type { ValidationIssue, ValidationContext } from "./types";

--- a/src/lib/auto-form/validation/object.ts
+++ b/src/lib/auto-form/validation/object.ts
@@ -1,0 +1,31 @@
+import type { AnyField } from "../normalizers/types";
+import { ensureRequired } from "./helpers";
+import type { ValidationContext, ValidationIssue, ValidatorFn } from "./types";
+
+// WHY: Object validators coordinate nested validation while also supporting a
+// top-level required flag. This keeps deeply nested forms consistent without
+// duplicating traversal logic in every consumer.
+export const validateObjectField = (
+  field: Extract<AnyField, { type: "object" }>,
+  value: unknown,
+  context: ValidationContext,
+  path: string[],
+  validate: ValidatorFn
+): ValidationIssue[] => {
+  const source =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+
+  const issues: ValidationIssue[] = [];
+
+  issues.push(...ensureRequired(field, source, path));
+
+  for (const [key, child] of Object.entries(field.properties)) {
+    issues.push(
+      ...validate(child as AnyField, source[key], context, [...path, key])
+    );
+  }
+
+  return issues;
+};

--- a/src/lib/auto-form/validation/primitive.ts
+++ b/src/lib/auto-form/validation/primitive.ts
@@ -1,0 +1,15 @@
+import type { AnyField } from "../normalizers/types";
+import { ensureRequired } from "./helpers";
+import type { ValidationContext, ValidationIssue } from "./types";
+
+// WHY: Primitive fields only enforce required semantics at this stage. More
+// specialized business rules can layer on in future phases without complicating
+// the base validator.
+export const validatePrimitiveField = (
+  field: AnyField,
+  value: unknown,
+  _context: ValidationContext,
+  path: string[]
+): ValidationIssue[] => {
+  return ensureRequired(field, value, path);
+};

--- a/src/lib/auto-form/validation/record.ts
+++ b/src/lib/auto-form/validation/record.ts
@@ -1,0 +1,26 @@
+import type { AnyField } from "../normalizers/types";
+import { ensureRequired, isValueEmpty } from "./helpers";
+import type { ValidationContext, ValidationIssue } from "./types";
+
+// WHY: Record fields are captured as plain objects after normalization. The
+// validator ensures at least one meaningful entry exists when the field is
+// required and defers per-value validation to the nested AutoField instances.
+export const validateRecordField = (
+  field: Extract<AnyField, { type: "record" }>,
+  value: unknown,
+  _context: ValidationContext,
+  path: string[]
+): ValidationIssue[] => {
+  if (!field.required) {
+    return [];
+  }
+
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const entries = Object.values(value as Record<string, unknown>);
+    if (entries.some((entry) => !isValueEmpty(entry))) {
+      return [];
+    }
+  }
+
+  return ensureRequired(field, value, path);
+};

--- a/src/lib/auto-form/validation/types.ts
+++ b/src/lib/auto-form/validation/types.ts
@@ -1,0 +1,33 @@
+import type { FieldSchema } from "../schemas";
+import type z from "zod";
+import type { AnyField } from "../normalizers/types";
+
+/**
+ * Shared contract for validation helpers.
+ */
+export type ValidationField = AnyField | z.infer<typeof FieldSchema>;
+
+/**
+ * Structured description of a validation problem encountered while traversing
+ * the schema.
+ */
+export interface ValidationIssue {
+  /** Dot-free path segments pointing to the offending field. */
+  path: string[];
+  /** Human friendly message explaining what went wrong. */
+  message: string;
+}
+
+/**
+ * Placeholder context object to keep validator signatures aligned with the
+ * normalizers. Later phases can extend this surface without refactoring each
+ * helper.
+ */
+export interface ValidationContext {}
+
+export type ValidatorFn = (
+  field: ValidationField,
+  value: unknown,
+  context: ValidationContext,
+  path: string[]
+) => ValidationIssue[];

--- a/src/lib/auto-form/validation/union.ts
+++ b/src/lib/auto-form/validation/union.ts
@@ -1,0 +1,40 @@
+import type { AnyField, UnionOptionsValue } from "../normalizers/types";
+import { ensureRequired, isValueEmpty, createIssue } from "./helpers";
+import type { ValidationContext, ValidationIssue, ValidatorFn } from "./types";
+
+// WHY: Unions present several possible shapes but only one active option should
+// be validated at a time. The validator focuses on the selected option so users
+// receive actionable feedback tied to the visible inputs.
+export const validateUnionField = (
+  field: Extract<AnyField, { type: "union" }>,
+  value: unknown,
+  context: ValidationContext,
+  path: string[],
+  validate: ValidatorFn
+): ValidationIssue[] => {
+  const unionValue =
+    value && typeof value === "object"
+      ? (value as UnionOptionsValue)
+      : ({ selected: 0, options: [] } as UnionOptionsValue);
+
+  const selectedIndex = Number(unionValue.selected ?? 0);
+  const normalizedIndex = Number.isNaN(selectedIndex) ? 0 : selectedIndex;
+  const optionField = field.anyOf[normalizedIndex] as AnyField | undefined;
+  const optionValue = unionValue.options?.[normalizedIndex];
+  const optionPath = [...path, "options", normalizedIndex.toString()];
+
+  if (!optionField) {
+    return [
+      createIssue(
+        path,
+        field.errorMessage ?? `${field.title} has an invalid selection`
+      ),
+    ];
+  }
+
+  if (field.required && isValueEmpty(optionValue)) {
+    return ensureRequired(field, optionValue, optionPath);
+  }
+
+  return validate(optionField, optionValue, context, optionPath);
+};

--- a/test/auto-form.react-hook-form.spec.tsx
+++ b/test/auto-form.react-hook-form.spec.tsx
@@ -333,4 +333,42 @@ describe("auto-form component suite", () => {
 
     expect(handleSubmit).not.toHaveBeenCalled();
   });
+
+  test("prevents submit when required arrays are empty", async () => {
+    const user = userEvent.setup();
+    const handleSubmit = vi.fn();
+
+    const schema = {
+      fields: {
+        tags: {
+          type: "array",
+          title: "Tags",
+          required: true,
+          errorMessage: "Add at least one tag",
+          itemType: { type: "string", title: "Tag" },
+        },
+      },
+    } satisfies z.infer<typeof FormSchema>;
+
+    const { container } = render(
+      <AutoForm schema={schema} onSubmit={handleSubmit} />
+    );
+
+    const form = container.querySelector("form");
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(handleSubmit).not.toHaveBeenCalled();
+    });
+
+    await user.click(screen.getByRole("button", { name: /add item/i }));
+    const tagInput = screen.getByRole("textbox");
+    await user.type(tagInput, "remote");
+
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/test/normalizers/normalize-value.spec.ts
+++ b/test/normalizers/normalize-value.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { normalizeValue } from "../../src/lib/auto-form/normalizers";
+import type { AnyField } from "../../src/lib/auto-form/normalizers/types";
+
+describe("normalizeValue", () => {
+  it("returns primitive values unchanged", () => {
+    const field = { type: "string", title: "Name" } as AnyField;
+    expect(normalizeValue(field, "hello")).toBe("hello");
+  });
+
+  it("converts empty strings to undefined", () => {
+    const field = { type: "string", title: "Name" } as AnyField;
+    expect(normalizeValue(field, "")).toBeUndefined();
+  });
+
+  it("formats date-like primitives", () => {
+    const field = { type: "date", title: "Birthday" } as AnyField;
+    const result = normalizeValue(field, new Date("2024-05-04T00:00:00Z"));
+    expect(result).toBe("2024-05-04");
+  });
+
+  it("recursively normalizes object fields", () => {
+    const field = {
+      type: "object",
+      title: "Address",
+      properties: {
+        street: { type: "string", title: "Street" },
+        moveIn: { type: "date", title: "Move in" },
+      },
+    } as AnyField;
+
+    const result = normalizeValue(field, {
+      street: "123 Main",
+      moveIn: new Date("2022-01-02T10:00:00Z"),
+    });
+
+    expect(result).toEqual({
+      street: "123 Main",
+      moveIn: "2022-01-02",
+    });
+  });
+
+  it("normalizes array items with their item schema", () => {
+    const field = {
+      type: "array",
+      title: "Tags",
+      itemType: { type: "time", title: "Tag" },
+    } as AnyField;
+
+    const result = normalizeValue(field, [new Date("2022-01-02T10:30:00Z"), "11:00"]);
+
+    expect(result).toEqual(["10:30", "11:00"]);
+  });
+
+  it("drops invalid record entries while coercing keys", () => {
+    const field = {
+      type: "record",
+      title: "Metadata",
+      keyType: "number",
+      valueType: { type: "string", title: "Value" },
+    } as AnyField;
+
+    const result = normalizeValue(field, [
+      { key: "1", value: "one" },
+      { key: "bad", value: "skip" },
+      { key: 2, value: "two" },
+    ]);
+
+    expect(result).toEqual({
+      "1": "one",
+      "2": "two",
+    });
+  });
+
+  it("hydrates union options when no value is provided", () => {
+    const field = {
+      type: "union",
+      title: "Choice",
+      anyOf: [
+        { type: "string", title: "Text" },
+        { type: "number", title: "Count" },
+      ],
+    } as AnyField;
+
+    const result = normalizeValue(field, undefined);
+
+    expect(result).toEqual({
+      selected: 0,
+      options: [undefined, undefined],
+    });
+  });
+});

--- a/test/validation/validate-value.spec.ts
+++ b/test/validation/validate-value.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { validateValue } from "../../src/lib/auto-form/validation";
+import type { AnyField } from "../../src/lib/auto-form/normalizers/types";
+
+describe("validateValue", () => {
+  it("flags missing required primitives", () => {
+    const field = {
+      type: "string",
+      title: "Full name",
+      required: true,
+    } as AnyField;
+
+    const issues = validateValue(field, undefined, undefined, ["fullName"]);
+
+    expect(issues).toEqual([
+      { path: ["fullName"], message: "Full name is required" },
+    ]);
+  });
+
+  it("validates required arrays when empty", () => {
+    const field = {
+      type: "array",
+      title: "Tags",
+      required: true,
+      errorMessage: "Add at least one tag",
+      itemType: { type: "string", title: "Tag" },
+    } as AnyField;
+
+    const issues = validateValue(field, [], undefined, ["tags"]);
+
+    expect(issues).toEqual([
+      { path: ["tags"], message: "Add at least one tag" },
+    ]);
+  });
+
+  it("validates required record fields without entries", () => {
+    const field = {
+      type: "record",
+      title: "Metadata",
+      required: true,
+      errorMessage: "Provide at least one entry",
+      keyType: "string",
+      valueType: { type: "string", title: "Value" },
+    } as AnyField;
+
+    const issues = validateValue(field, {}, undefined, ["metadata"]);
+
+    expect(issues).toEqual([
+      { path: ["metadata"], message: "Provide at least one entry" },
+    ]);
+  });
+
+  it("validates the active union option when required", () => {
+    const field = {
+      type: "union",
+      title: "Contact",
+      required: true,
+      anyOf: [
+        { type: "string", title: "Email" },
+        { type: "string", title: "Phone" },
+      ],
+    } as AnyField;
+
+    const issues = validateValue(
+      field,
+      { selected: 1, options: [undefined, undefined] },
+      undefined,
+      ["contact"]
+    );
+
+    expect(issues).toEqual([
+      { path: ["contact", "options", "1"], message: "Contact is required" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated validation pipeline that mirrors the normalizers and re-export helpers for form utilities
- update AutoForm to run validation before submission, surface field errors via WithErrorMessage, and treat empty primitives as undefined during normalization
- extend unit tests to cover validation behaviour, normalization of empty strings, and blocking empty required arrays

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e9a348f9008323b8d812842fe3bd2c